### PR TITLE
Update Affirmations App for edge-to-edge support

### DIFF
--- a/app/src/main/java/com/example/affirmations/MainActivity.kt
+++ b/app/src/main/java/com/example/affirmations/MainActivity.kt
@@ -20,10 +20,16 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
@@ -34,6 +40,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,13 +69,26 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun AffirmationsApp() {
-    AffirmationList(
-        affirmationList = Datasource().loadAffirmations(),
-    )
+    val layoutDirection = LocalLayoutDirection.current
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(
+                start = WindowInsets.safeDrawing.asPaddingValues()
+                    .calculateStartPadding(layoutDirection),
+                end = WindowInsets.safeDrawing.asPaddingValues()
+                    .calculateEndPadding(layoutDirection),
+            ),
+    ) {
+        AffirmationsList(
+            affirmationList = Datasource().loadAffirmations(),
+        )
+    }
 }
 
 @Composable
-fun AffirmationList(affirmationList: List<Affirmation>, modifier: Modifier = Modifier) {
+fun AffirmationsList(affirmationList: List<Affirmation>, modifier: Modifier = Modifier) {
     LazyColumn(modifier = modifier) {
         items(affirmationList) { affirmation ->
             AffirmationCard(


### PR DESCRIPTION
This commit updates the Affirmations app to support edge-to-edge display.

The following changes were made:
- Added necessary imports for `WindowInsets`, `asPaddingValues`, `calculateEndPadding`, `calculateStartPadding`, `safeDrawing`, `statusBarsPadding`, and `LocalLayoutDirection`.
- Wrapped the `AffirmationList` composable in a `Surface` to handle system insets.
- Applied `statusBarsPadding()` and additional padding using `WindowInsets.safeDrawing` to ensure content is not obscured by system bars.
- Renamed `AffirmationList` to `AffirmationsList` for consistency.